### PR TITLE
Prevents auto-fill

### DIFF
--- a/mail.yaml
+++ b/mail.yaml
@@ -64,7 +64,9 @@ forms:
           type: email
           label: Username of your mail-account
           placeholder: My Username
+          autocomplete: off
 
         password:
           type: password
           label: Password of your mail-account
+          autocomplete: new-password


### PR DESCRIPTION
Prevent auto-fill of username/password by password managers that might confuse these fields for login fields for the site.

https://github.com/typemill/typemill/issues/366